### PR TITLE
Enable Python3 support

### DIFF
--- a/bulkupload.py
+++ b/bulkupload.py
@@ -45,7 +45,7 @@ def upload_file(path, attempts=0):
      and return True if successful. '''
 
     try:
-        opened_source_file = open(path, 'r')
+        opened_source_file = open(path, 'rb')
     except IOError:
         print("Error opening: " + path)
         return False
@@ -66,7 +66,7 @@ def upload_file(path, attempts=0):
             path,
             opened_source_file)
 
-    except Exception, e:
+    except Exception as e:
 
         olrc_connect()
         time.sleep(1)
@@ -101,7 +101,7 @@ def olrc_connect():
         AUTH_TOKEN = auth_token
         global STORAGE_URL
         STORAGE_URL = connection_storage_url
-    except swiftclient.client.ClientException, e:
+    except swiftclient.client.ClientException as e:
         print(e)
         sys.stdout.flush()
         sys.stdout.write(
@@ -122,7 +122,7 @@ def create_container():
     try:
         swiftclient.client.put_container(STORAGE_URL, AUTH_TOKEN, CONTAINER)
 
-    except swiftclient.client.ClientException, e:
+    except swiftclient.client.ClientException as e:
         print(e)
         sys.stdout.flush()
         sys.stdout.write(
@@ -139,8 +139,8 @@ def env_vars_set():
 
     global REQUIRED_VARIABLES
     for required_variable in REQUIRED_VARIABLES:
-        if (not os.environ.get(required_variable)
-                and os.environ.get(required_variable) != ""):
+        if (required_variable not in os.environ
+                and os.environ[required_variable] != ""):
             return False
 
     return True
@@ -151,14 +151,14 @@ def set_env_vars():
     environment.'''
 
     global SWIFT_AUTH_URL
-    SWIFT_AUTH_URL = os.environ.get("OS_AUTH_URL")
+    SWIFT_AUTH_URL = os.environ["OS_AUTH_URL"]
 
     global USERNAME
-    USERNAME = os.environ.get("OS_TENANT_NAME") + \
-        ":" + os.environ.get("OS_USERNAME")
+    USERNAME = os.environ["OS_TENANT_NAME"] + \
+        ":" + os.environ["OS_USERNAME"]
 
     global PASSWORD
-    PASSWORD = os.environ.get("OS_PASSWORD")
+    PASSWORD = os.environ["OS_PASSWORD"]
 
     return
 

--- a/olrcdb.py
+++ b/olrcdb.py
@@ -19,11 +19,12 @@ class DatabaseConnection(object):
                 charset='utf8',
             )
             self.cursor = self.db.cursor()
-        except KeyError:
+        except KeyError as e:
+            print(e)
             sys.exit("Please make sure all required environment variables"
                      " are set:\n$MYSQL_HOST\n$MYSQL_DB\n$MYSQL_USER\n"
                      "$MYSQL_PASSWD\n")
-        except MySQLdb.Error, e:
+        except MySQLdb.Error as e:
             sys.exit("ERROR {0} IN CONNECTION: {1}".format(
                 e.args[0], e.args[1]
             ))
@@ -47,7 +48,7 @@ class DatabaseConnection(object):
 
         try:
             self.cursor.execute(query)
-        except MySQLdb.Error, e:
+        except MySQLdb.Error as e:
             sys.exit("ERROR {0} IN TABLE CREATION: {1}".format(
                 e.args[0],
                 e.args[1]
@@ -77,7 +78,7 @@ class DatabaseConnection(object):
         try:
             self.cursor.execute(query)
             self.db.commit()
-        except MySQLdb.Error, e:
+        except MySQLdb.Error as e:
             sys.exit("ERROR {0} IN QUERY: {1}\nQuery:{2}".format(
                 e.args[0],
                 e.args[1],


### PR DESCRIPTION
This should (theoretically) also work with recent versions of Python2.

Minor changes:

* from os.environ.get('FOO') to os.environ['FOO']
* from except Exception, e to except Exception as e
* use binary mode to open files that will be uploaded

Signed-off-by: Dan Scott <dan@coffeecode.net>